### PR TITLE
Update MAKEME.md

### DIFF
--- a/Week3/MAKEME.md
+++ b/Week3/MAKEME.md
@@ -7,8 +7,6 @@ Topics discussed this week:
 • Callbacks
 ```
 
->[Here](https://github.com/HackYourFuture/JavaScript3/tree/master/Week1) you find the readings you have to complete before the first JavaScript3 lecture.
-
 ## Step 1: Feedback
 
 _Deadline Monday_


### PR DESCRIPTION
Reading material for JS3 is already mentioned below (bottom of the page).

In addition, I would suggest to transfer the readings (under header Step 2: Read) to the README.md. Currently there are more readings in the MAKEME.md than in the README, which is a bit confusing. Perhaps a mere link to the README.md would be more appropriate here.